### PR TITLE
Load tls certs dynamically

### DIFF
--- a/edgerouter/edgerouter.go
+++ b/edgerouter/edgerouter.go
@@ -218,7 +218,14 @@ func (er *EdgeRouter) StartEdgeRouter(ctx context.Context, wg *sync.WaitGroup, c
 	go func() {
 		log.Infof("Websocket listening on %s", er.httpServer.Addr)
 		if *certPath != "" && *certKeyPath != "" {
-			if err := er.httpServer.ListenAndServeTLS(*certPath, *certKeyPath); err != nil {
+			er.httpServer.TLSConfig.GetCertificate = func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				cert, err := tls.LoadX509KeyPair(*certPath, *certKeyPath)
+				if err != nil {
+					return nil, err
+				}
+				return &cert, nil
+			}
+			if err := er.httpServer.ListenAndServeTLS("", ""); err != nil {
 				log.Warn(err)
 			}
 		} else {

--- a/router/router.go
+++ b/router/router.go
@@ -166,7 +166,14 @@ func (r *MMSRouter) StartRouter(ctx context.Context, wg *sync.WaitGroup, certPat
 	go func() {
 		log.Infof("Websocket listening on: %v", r.httpServer.Addr)
 		if *certPath != "" && *certKeyPath != "" {
-			if err := r.httpServer.ListenAndServeTLS(*certPath, *certKeyPath); err != nil {
+			r.httpServer.TLSConfig.GetCertificate = func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				cert, err := tls.LoadX509KeyPair(*certPath, *certKeyPath)
+				if err != nil {
+					return nil, err
+				}
+				return &cert, nil
+			}
+			if err := r.httpServer.ListenAndServeTLS("", ""); err != nil {
 				log.Error(err)
 			}
 		} else {


### PR DESCRIPTION
By loading tls client and host certs dynamically on runtime when we need them instead of loading them on startup, we don't need to restart the application when we get a new client cert from the MIR or a new host cert from e.g. let's encrypt